### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ pod install
 ```
 
 2) Undefined symbols for architecture armv7: "_OBJC_CLASS_$_AppAnalytics", referenced from ... .
-Happens when you override cocoa pods linker flags in your target.
+Happens when you override CocoaPods linker flags in your target.
 ```
 Go to your target Build Settings -> Other linker flags -> double click. Add $(inherited) to a new line .
 ```


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
